### PR TITLE
fix: register standard library for cloud workflow tests

### DIFF
--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -31,8 +31,16 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Checkout standard library
+        uses: actions/checkout@v4
+        with:
+          repository: griptape-ai/griptape-nodes-library-standard
+          path: griptape-nodes-library-standard
+
       - name: Install dependencies
         run: uv pip install --system griptape-nodes pytest pytest-asyncio python-dotenv
 
       - name: Run workflow tests
         run: pytest -s tests/workflows
+        env:
+          ADDITIONAL_LIBRARY_JSONS: ${{ github.workspace }}/griptape-nodes-library-standard/griptape_nodes_library.json

--- a/tests/workflows/test_workflows.py
+++ b/tests/workflows/test_workflows.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
@@ -55,10 +56,14 @@ async def setup_test_library(griptape_nodes: GriptapeNodes) -> AsyncGenerator[No
     # Save the original libraries state
     original_libraries = config_manager.get_config_value(key=LIBRARIES_TO_REGISTER_KEY, default=[])
 
-    # Set this library for testing
+    # Set this library for testing, plus any additional libraries specified via env var
+    libraries = [str(LIBRARY_ROOT / "griptape_nodes_library.json")]
+    additional = os.environ.get("ADDITIONAL_LIBRARY_JSONS", "")
+    if additional:
+        libraries.extend(p for p in additional.split(os.pathsep) if p)
     config_manager.set_config_value(
         key=LIBRARIES_TO_REGISTER_KEY,
-        value=[str(LIBRARY_ROOT / "griptape_nodes_library.json")],
+        value=libraries,
     )
 
     yield  # Run all tests


### PR DESCRIPTION
## Summary

- The griptape-cloud workflow template depends on nodes from `Griptape Nodes Library` (standard library) — `MergeTexts`, `Agent`, `Note`, `SeedreamImageGeneration`
- CI only registered the cloud library, so those nodes became error-proxy placeholders and the flow failed at runtime
- Adds a step to clone the standard library repo and pass its JSON path via `ADDITIONAL_LIBRARY_JSONS` env var
- Test now reads that env var and registers additional libraries alongside the cloud library

## Test plan

- [x] Ran `pytest -s tests/workflows` locally — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)