### PR TITLE
Fix post_build_install_script if no HF_TOKEN is found

### DIFF
--- a/griptape_cloud/publish_workflow/griptape_cloud_publisher.py
+++ b/griptape_cloud/publish_workflow/griptape_cloud_publisher.py
@@ -853,6 +853,8 @@ class GriptapeCloudPublisher(GriptapeCloudApiMixin):
                         hf_token = hf_get_token()
                         if hf_token:
                             f.write(f"\nexport HF_TOKEN='{hf_token}'\n")
+                        else:
+                            f.write("\n")
                         f.write("python download_models_script.py\n")
                     self._normalize_line_endings(temp_post_build_install_script_path)
 


### PR DESCRIPTION
* Fix post_build_install_script if no HF_TOKEN is found

Fixes this error on Structure deployment:

```bash
python: can't open file '/structure/register_libraries_script.pypython': [Errno 2] No such file or directory

The command '/bin/sh -c chmod +x post_build_install_script.sh && ./post_build_install_script.sh' returned a non-zero code: 2

2026/03/24 19:26:43 Container failed during run: build. No retries remaining.
```